### PR TITLE
Add Requirements section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,11 @@ This directory contains the SDK for ST31 applications development
 
 Make sure to use the tagged version matching your development environment as syscalls IDs might have changed
 
+## Requirements
+```
+sudo pip install Pillow
+```
+
+make sure to call the above outside of any virtual enviroment you may be in. ```icon.py``` is called from ```Makefile.glyphs```, calling the system's python version. 
+
 


### PR DESCRIPTION
On a fresh Python install, When compiling ```Makefile.glyphs``` (from https://github.com/zcoinofficial/blue-app-btc), glyph compilation fails. The single dependancy necessary is the pip module ```Pillow```. This request adds a 'Requirements' section to include this dependancy.