### PR TITLE
Allow for custom script.ld

### DIFF
--- a/Makefile.defines
+++ b/Makefile.defines
@@ -27,6 +27,10 @@ endif
 COMMON_LOAD_PARAMS=--tlv --targetId $(TARGET_ID) --delete --fileName bin/app.hex --appName $(APPNAME) --appVersion $(APPVERSION) --dataSize `cat debug/app.map |grep _nvram_data_size | tr -s ' ' | cut -f2 -d' '` `ICONHEX=\`python $(BOLOS_SDK)/icon.py $(ICONNAME) hexbitmaponly 2>/dev/null\` ; [ ! -z "$$ICONHEX" ] && echo "--icon $$ICONHEX"` $(PARAM_SCP)
 COMMON_DELETE_PARAMS=--targetId $(TARGET_ID) --appName $(APPNAME) $(PARAM_SCP)
 
+ifndef SCRIPT_LD
+    SCRIPT_LD:=$(BOLOS_SDK)/script.ld
+endif
+
 ### platform definitions
 DEFINES += ST31 gcc __IO=volatile
 
@@ -54,4 +58,4 @@ LDFLAGS  += -Wall
 LDFLAGS  += -mcpu=cortex-m0 -mthumb 
 LDFLAGS  += -fno-common -ffunction-sections -fdata-sections -fwhole-program -nostartfiles 
 LDFLAGS  += -mno-unaligned-access
-LDFLAGS  += -T$(BOLOS_SDK)/script.ld  -Wl,--gc-sections -Wl,-Map,debug/app.map,--cref
+LDFLAGS  += -T$(SCRIPT_LD)  -Wl,--gc-sections -Wl,-Map,debug/app.map,--cref

--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -55,7 +55,7 @@ obj/%.o: %.s
 	@echo "[AS]   $@"
 	$(call log,$(call as_cmdline,$(INCLUDES_PATH), $(DEFINES),$<,$@))
 
-bin/app.elf: $(OBJECT_FILES) $(BOLOS_SDK)/script.ld
+bin/app.elf: $(OBJECT_FILES) $(SCRIPT_LD)
 	@echo "[LINK] $@"
 	$(call log,$(call link_cmdline,$(OBJECT_FILES) $(LDLIBS),$@))
 	$(call log,$(GCCPATH)arm-none-eabi-objcopy -O ihex -S bin/app.elf bin/app.hex)


### PR DESCRIPTION
Sometimes it is necessary to modify the default script.ld file.

At the moment, this requires patching or forking the SDK.

This PR adds a setting to override the script.ld location.