### PR TITLE
sed fix for names that contain but do not end in '.c'

### DIFF
--- a/Makefile.rules_generic
+++ b/Makefile.rules_generic
@@ -68,7 +68,7 @@ bin/app.elf: $(OBJECT_FILES) $(SCRIPT_LD)
 link_cmdline = $(LD) $(LDFLAGS) -o $(2) $(1)
 
 # dep_cmdline(include,defines,src($<),dest($@))	Macro that is used to format arguments for the dependency creator
-dep_cmdline = $(CC) -M $(CFLAGS) $(addprefix -D,$(2)) $(addprefix -I,$(1)) $(3) | sed 's/\($*\)\.o[ :]*/obj\/\1.o: /g' | sed -e 's/[:\t ][^ ]\+\.c//g' > dep/$(basename $(notdir $(4))).d 2>/dev/null
+dep_cmdline = $(CC) -M $(CFLAGS) $(addprefix -D,$(2)) $(addprefix -I,$(1)) $(3) | sed 's/\($*\)\.o[ :]*/obj\/\1.o: /g' | sed -e 's/$$/ /' | sed -e 's/[:\t ][^ ]\+\.c / /g' | sed -e 's/ +/ /g' | sed -e 's/ $$//' > dep/$(basename $(notdir $(4))).d 2>/dev/null
 
 # cc_cmdline(include,defines,src,dest)	Macro that is used to format arguments for the compiler
 cc_cmdline = $(CC) -c $(CFLAGS) $(addprefix -D,$(2)) $(addprefix -I,$(1)) -o $(4) $(3)


### PR DESCRIPTION
If we start with the `blue-app-helloworld` and
```
cd src/
mkdir github.com
touch github.com/should_work.h
```
and inside `github.com/should_work.c` we can write simply:
```
#include "should_work.h"
```
then when trying to build with the standard SDK Makefile we get an error:
```
make: *** No rule to make target 'om/should_work.h', needed by 'obj/should_work.o'.  Stop.
```
This is because the last `sed` regular expression fixed in this PR incorrectly matches the `github.com` because it doesn't require that the word end after the `.c`. This PR fixes that by introducing appending a space at the end of every line, then requiring a space after the `.c` extension which ensures that filenames will incorrectly match less frequently. To fix any possible spacing errors extra spaces are removed using additional `sed`'s at the end.