### PR TITLE
SDK 1.6.1-2 differences from the 1.6.1.1

### DIFF
--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -1040,11 +1040,11 @@ unsigned int os_io_seproxyhal_get_app_name_and_version(void) {
 
 #ifndef HAVE_BOLOS
   // append app name
-  len = os_registry_get_current_app_tag(BOLOS_TAG_APPNAME, G_io_apdu_buffer+tx_len+1, sizeof(G_io_apdu_buffer)-tx_len);
+  len = os_registry_get_current_app_tag(BOLOS_TAG_APPNAME, G_io_apdu_buffer+tx_len+1, sizeof(G_io_apdu_buffer)-tx_len-1);
   G_io_apdu_buffer[tx_len++] = len;
   tx_len += len;
   // append app version
-  len = os_registry_get_current_app_tag(BOLOS_TAG_APPVERSION, G_io_apdu_buffer+tx_len+1, sizeof(G_io_apdu_buffer)-tx_len);
+  len = os_registry_get_current_app_tag(BOLOS_TAG_APPVERSION, G_io_apdu_buffer+tx_len+1, sizeof(G_io_apdu_buffer)-tx_len-1);
   G_io_apdu_buffer[tx_len++] = len;
   tx_len += len;
 #else // HAVE_BOLOS


### PR DESCRIPTION
Fix an off-by-one bug in `os_registry_get_current_app_tag` triggered by the `B001000000` call.
It was making Speculos crazy when requested.