### PR TITLE
Fix compilation warning when HAVE_IO_USB and HAVE_BLE are not defined

### DIFF
--- a/src/os_io_seproxyhal.c
+++ b/src/os_io_seproxyhal.c
@@ -394,7 +394,9 @@ void io_seproxyhal_handle_capdu_event(void) {
 }
 
 unsigned int io_seproxyhal_handle_event(void) {
+#if defined(HAVE_IO_USB) || defined(HAVE_BLE)
   unsigned int rx_len = U2BE(G_io_seproxyhal_spi_buffer, 1);
+#endif
 
 #ifdef HAVE_BLE
   // continue sending the ble db saved if any


### PR DESCRIPTION
This PR suppresses an "unused variable" warning during compilation when `HAVE_IO_USB` and `HAVE_BLE` are not defined.
This is typically the case for Ethereum plugins.