### PR TITLE
Fix several compilation warnings and replace default PRINTF function

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -123,7 +123,10 @@ os is not an application (it calls ux upon user inputs)
 void screen_printf(const char *format, ...);
 void mcu_usb_printf(const char *format, ...);
 #else // !HAVE_PRINTF
-#define PRINTF(...)
+void silent_printf(const char *restrict format, ...);
+#if !defined(PRINTF)
+#define PRINTF silent_printf
+#endif // !defined(PRINTF)
 #endif // !HAVE_PRINTF
 
 // redefined if string.h not included

--- a/src/os.c
+++ b/src/os.c
@@ -21,6 +21,7 @@
 #include "os_helpers.h"
 #include "os_io.h"
 #include "os_utils.h"
+#include "os.h"
 #include <string.h>
 
 // apdu buffer must hold a complete apdu to avoid troubles

--- a/src/os_printf.c
+++ b/src/os_printf.c
@@ -557,8 +557,11 @@ error:
     //
     va_end(vaArgP);
 }
-
-#endif // HAVE_PRINTF
+#else // !HAVE_PRINTF
+void silent_printf(const char *restrict format, ...) {
+    (void) format;
+}
+#endif // !HAVE_PRINTF
 
 #ifdef HAVE_SPRINTF
 //unsigned int snprintf(unsigned char * str, unsigned int str_size, const char* format, ...)

--- a/src/os_printf.c
+++ b/src/os_printf.c
@@ -21,12 +21,9 @@
 
 #if defined(HAVE_BOLOS)
 # include "bolos_target.h"
-# include "os_math.h"
 #endif // HAVE_BOLOS
 
-#if !defined(MIN)
-# define MIN(x,y) ((x)<(y)?(x):(y))
-#endif // MIN
+#include "os_math.h"
 
 #if defined(HAVE_PRINTF) || defined(HAVE_SPRINTF)
 


### PR DESCRIPTION
- Fix "warning: implicit declaration of function 'screen_printf'" when compiling with DEBUG=1
- Fix "warning: 'MIN' macro redefined" when compiling with DEBUG=1
- Replace default empty PRINTF by a silent cast function
- Full backward compatibility