### PR TITLE
Fix clang analyzer error

### DIFF
--- a/include/os_utils.h
+++ b/include/os_utils.h
@@ -23,7 +23,7 @@
   ((((hi3)&0xFFu) << 24) | (((hi2)&0xFFu) << 16) | (((lo1)&0xFFu) << 8) |      \
    ((lo0)&0xFFu))
 static inline uint16_t U2BE(const uint8_t *buf, size_t off) {
-  return (buf[off] << 8) | buf[off + 1];
+  return buf ? (buf[off] << 8) | buf[off + 1] : 0;
 }
 static inline uint32_t U4BE(const uint8_t *buf, size_t off) {
   return (((uint32_t)buf[off]) << 24) | (buf[off + 1] << 16) |


### PR DESCRIPTION
PR https://github.com/LedgerHQ/app-solana/actions/runs/3183283776/jobs/5201485431 fails with:
```
/opt/nanos-secure-sdk/include/os_utils.h:26:11: warning: Array access (from variable 'buf') results in a null pointer dereference [core.NullDereference]
  return (buf[off] << 8) | buf[off + 1];
          ^~~~~~~~
```