### PR TITLE
Provide (void) argument list for os_boot()'s prototype.

### DIFF
--- a/include/os.h
+++ b/include/os.h
@@ -88,7 +88,7 @@
 void app_main(void);
 
 // os initialization function to be called by application entry point
-void os_boot();
+void os_boot(void);
 
 /**
  * Function takes 0 for first call. Returns 0 when timeout has occured. Returned


### PR DESCRIPTION
I need this so that I can use `-Wmissing-prototypes` as clang does not recognise a prototype as valid if the argument list is empty rather than void.