### PR TITLE
declare UNUSED macro as it's declared in common SDK

### DIFF
--- a/include/os_helpers.h
+++ b/include/os_helpers.h
@@ -14,5 +14,6 @@ unsigned int os_parse_bertlv(unsigned char *mem,
                              unsigned int   offset,
                              void         **buffer,
                              unsigned int   maxlength);
-
+#ifndef UNUSED
 #define UNUSED(x) (void) x
+#endif


### PR DESCRIPTION
I'm facing a build issue in the CI for Polkadot and this seems to be the problem. Just missing the verification if `UNUSED` is not declared.

https://github.com/LedgerHQ/ledger-secure-sdk/blob/e8b56c451ff9336a71fc746a5d9a1ef40a7d4855/include/os_helpers.h#L18-L20