### PR TITLE
Implement cx_bn_gf2_n_mul

### DIFF
--- a/include/ox_bn.h
+++ b/include/ox_bn.h
@@ -1075,4 +1075,32 @@ SYSCALL cx_err_t cx_bn_next_prime(cx_bn_t n);
  */
 SYSCALL cx_err_t cx_bn_rng(cx_bn_t r, const cx_bn_t n);
 
+/**
+ * @brief Performs a multiplication over GF(2^n).
+ *
+ * @details *bn_r* must be distinct from *bn_a* and *bn_b*.
+ *
+ * @param[out] bn_r BN index for the result.
+ *
+ * @param[in]  bn_a BN index of the first operand.
+ *
+ * @param[in]  bn_b BN index of the second operand.
+ *
+ * @param[in]  bn_n BN index of the modulus.
+ *                  The modulus must be an irreducible polynomial over GF(2)
+ *                  of degree n.
+ *
+ * @param[in]  bn_h BN index of the second montgomery constant.
+ *
+ * @return          Error code:
+ *                  - CX_OK on success
+ *                  - CX_NOT_LOCKED
+ *                  - CX_INVALID_PARAMETER
+ *                  - CX_MEMORY_FULL
+ */
+WARN_UNUSED_RESULT cx_err_t cx_bn_gf2_n_mul(cx_bn_t       bn_r,
+                                            const cx_bn_t bn_a,
+                                            const cx_bn_t bn_b,
+                                            const cx_bn_t bn_n,
+                                            const cx_bn_t bn_h);
 #endif /* CX_BN_H */


### PR DESCRIPTION
Fixes #64

This PR is a workaround that implements `cx_bn_gf2_n_mul()` in the SDK until it is hopefully added as a syscall like in all other Ledger devices.

As the second Montgomery constant (`bn_h`) is an unused attribute here it begs the question how is the second Montgomery constant (`bn_h`) used in the implementation of `cx_bn_gf2_n_mul()` on Nano S Plus, Nano X and Stax devices? Is it also unused on these devices?


> [!NOTE]
> The code in this PR is already included in the [app-seed-tool](https://github.com/LedgerHQ/app-seed-tool) which has passed Ledger's security review.